### PR TITLE
Spirit

### DIFF
--- a/habit 2
+++ b/habit 2
@@ -1,0 +1,33 @@
+{
+  "name": "habit-tracker",
+  "version": "0.20.2",
+  "private": true,
+  "description": "Track your habits, progress, and journal entries.",
+  "homepage": "https://<your-username>.github.io/habit-tracker",
+  "dependencies": {
+    "chart.js": "^4.4.3",
+    "firebase": "^12.3.0",
+    "framer-motion": "^11.0.3",
+    "gh-pages": "^6.1.1",
+    "html2canvas": "^1.4.1",
+    "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.3.1",
+    "react-icons": "^5.2.1",
+    "react-router-dom": "^6.27.0",
+    "react-scripts": "5.0.1",
+    "workbox-*": "^6.6.0",
+    "zustand": "^5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "deploy": "npm run build && gh-pages -b gh-pages -d build",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": { "extends": ["react-app"] },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  }
+}

--- a/habit3
+++ b/habit3
@@ -1,0 +1,30 @@
+{
+  "name": "habit-tracker",
+  "version": "0.20.2",
+  "private": true,
+  "description": "Track habits and keep a journal for each one.",
+  "homepage": "https://<your-username>.github.io/habit-tracker",
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0",
+    "zustand": "^5.0.1",
+    "firebase": "^12.3.0",
+    "chart.js": "^4.4.3",
+    "react-chartjs-2": "^5.2.0",
+    "framer-motion": "^11.0.3",
+    "react-icons": "^5.2.1",
+    "html2canvas": "^1.4.1",
+    "workbox": "^6.6.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "deploy": "npm run build && gh-pages -b gh-pages -d build"
+  },
+  "eslintConfig": { "extends": ["react-app"] },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  }
+}


### PR DESCRIPTION
Merged all workbox-* packages → workbox

If you’re not using each module individually, install the full package instead:

npm install workbox


Makes code simpler and lighter.

Removed predeploy

Combined into a single deploy script to reduce redundancy:

"deploy": "npm run build && gh-pages -b gh-pages -d build"


Simplified description and formatting

Added homepage (needed for GitHub Pages)

Removed unnecessary quotes and extra newlines

{csd-c}